### PR TITLE
Fix link to Twitter account @HumansOfJulia

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <a href="https://github.com/Humans-of-Julia" class="icon-menu" title="" target="_blank" data-original-title="Cite">
         <i class="fa fa-github-square"></i>
       </a>
-      <a href="HumansOfJulia" class="icon-menu" title="" target="_blank" data-original-title="Cite">
+      <a href="https://twitter.com/HumansOfJulia" class="icon-menu" title="" target="_blank" data-original-title="Cite">
         <i class="fa fa-twitter-square"></i>
       </a>
       <a href="https://discord.gg/nPPZy4RYbP" class="icon-menu" title="" target="_blank" data-original-title="Cite">


### PR DESCRIPTION
I found @HumansOfJulia on Twitter, and I am assuming that it is the right twitter account for this community. Feel free to edit if incorrect.

The link was previously linked to https://humansofjulia.org/HumansOfJulia, which gave a Github 404 Page not found errpr.

