### PR TITLE
Fix link to Twitter account

### DIFF
--- a/content/content.jl
+++ b/content/content.jl
@@ -13,7 +13,7 @@ hoj_email = email("contact@humansofjulia.org") # obfuscated
 ## Social Networks (comment/delete lines to unwanted social network, input your personal info for the others)
 info["github"] = "https://github.com/Humans-of-Julia"
 info["discord"] = "https://discord.gg/nPPZy4RYbP"
-info["twitter"] = "HumansOfJulia"
+info["twitter"] = "https://twitter.com/HumansOfJulia"
 
 ######################################
 # Contributors user name => real name


### PR DESCRIPTION
There was a bug in the link which led to https://humansofjulia.org/HumansOfJulia, which gave a Github 404 Page not found error.
This fix updates the link to the proper url for Twitter.

As mentioned in #4 this is the proper file to change to update the link.